### PR TITLE
Generalize access token

### DIFF
--- a/src/main/scala/com/github/dakatsuka/akka/http/oauth2/client/AccessToken.scala
+++ b/src/main/scala/com/github/dakatsuka/akka/http/oauth2/client/AccessToken.scala
@@ -10,19 +10,21 @@ import scala.concurrent.Future
 
 case class AccessToken(
     accessToken: String,
-    tokenType: String,
-    expiresIn: Int,
-    refreshToken: Option[String]
+    tokenType: Option[String],
+    scope: Option[String],
+    refreshToken: Option[String],
+    expiresIn: Option[Int]
 )
 
 object AccessToken extends JsonUnmarshaller {
   implicit def decoder: Decoder[AccessToken] = Decoder.instance { c =>
     for {
       accessToken  <- c.downField("access_token").as[String].right
-      tokenType    <- c.downField("token_type").as[String].right
-      expiresIn    <- c.downField("expires_in").as[Int].right
+      tokenType    <- c.downField("token_type").as[Option[String]].right
+      scope        <- c.downField("scope").as[Option[String]].right
       refreshToken <- c.downField("refresh_token").as[Option[String]].right
-    } yield AccessToken(accessToken, tokenType, expiresIn, refreshToken)
+      expiresIn    <- c.downField("expires_in").as[Option[Int]].right
+    } yield AccessToken(accessToken, tokenType, scope, refreshToken, expiresIn)
   }
 
   def apply(response: HttpResponse)(implicit mat: Materializer): Future[AccessToken] = {

--- a/src/main/scala/com/github/dakatsuka/akka/http/oauth2/client/strategy/AuthorizationCodeStrategy.scala
+++ b/src/main/scala/com/github/dakatsuka/akka/http/oauth2/client/strategy/AuthorizationCodeStrategy.scala
@@ -28,7 +28,7 @@ class AuthorizationCodeStrategy extends Strategy(GrantType.AuthorizationCode) {
       method = config.tokenMethod,
       uri = uri,
       headers = List(
-        RawHeader("Accept", "*/*")
+        RawHeader("Accept", "application/json")
       ),
       FormData(
         params ++ Map(

--- a/src/main/scala/com/github/dakatsuka/akka/http/oauth2/client/strategy/ClientCredentialsStrategy.scala
+++ b/src/main/scala/com/github/dakatsuka/akka/http/oauth2/client/strategy/ClientCredentialsStrategy.scala
@@ -18,7 +18,7 @@ class ClientCredentialsStrategy extends Strategy(GrantType.ClientCredentials) {
       method = config.tokenMethod,
       uri = uri,
       headers = List(
-        RawHeader("Accept", "*/*")
+        RawHeader("Accept", "application/json")
       ),
       FormData(
         params ++ Map(

--- a/src/main/scala/com/github/dakatsuka/akka/http/oauth2/client/strategy/PasswordCredentialsStrategy.scala
+++ b/src/main/scala/com/github/dakatsuka/akka/http/oauth2/client/strategy/PasswordCredentialsStrategy.scala
@@ -21,7 +21,7 @@ class PasswordCredentialsStrategy extends Strategy(GrantType.PasswordCredentials
       method = config.tokenMethod,
       uri = uri,
       headers = List(
-        RawHeader("Accept", "*/*")
+        RawHeader("Accept", "application/json")
       ),
       FormData(
         params ++ Map(

--- a/src/main/scala/com/github/dakatsuka/akka/http/oauth2/client/strategy/RefreshTokenStrategy.scala
+++ b/src/main/scala/com/github/dakatsuka/akka/http/oauth2/client/strategy/RefreshTokenStrategy.scala
@@ -20,7 +20,7 @@ class RefreshTokenStrategy extends Strategy(GrantType.RefreshToken) {
       method = config.tokenMethod,
       uri = uri,
       headers = List(
-        RawHeader("Accept", "*/*")
+        RawHeader("Accept", "application/json")
       ),
       FormData(
         params ++ Map(

--- a/src/test/scala/com/github/dakatsuka/akka/http/oauth2/client/AccessTokenSpec.scala
+++ b/src/test/scala/com/github/dakatsuka/akka/http/oauth2/client/AccessTokenSpec.scala
@@ -26,9 +26,10 @@ class AccessTokenSpec extends FlatSpec with DiagrammedAssertions with ScalaFutur
 
   it should "apply from HttpResponse" in {
     val accessToken  = "xxx"
-    val tokenType    = "bearer"
-    val expiresIn    = 86400
-    val refreshToken = "yyy"
+    val tokenType    = Some("bearer")
+    val expiresIn    = Some(86400)
+    val refreshToken = Some("yyy")
+    val scope        = None
 
     val httpResponse = HttpResponse(
       status = StatusCodes.OK,
@@ -38,9 +39,9 @@ class AccessTokenSpec extends FlatSpec with DiagrammedAssertions with ScalaFutur
         s"""
            |{
            |  "access_token": "$accessToken",
-           |  "token_type": "$tokenType",
-           |  "expires_in": $expiresIn,
-           |  "refresh_token": "$refreshToken"
+           |  "token_type": "bearer",
+           |  "expires_in": 86400,
+           |  "refresh_token": "yyy"
            |}
          """.stripMargin
       )
@@ -51,8 +52,9 @@ class AccessTokenSpec extends FlatSpec with DiagrammedAssertions with ScalaFutur
     whenReady(result) { token =>
       assert(token.accessToken == accessToken)
       assert(token.tokenType == tokenType)
+      assert(token.scope == scope)
       assert(token.expiresIn == expiresIn)
-      assert(token.refreshToken.contains(refreshToken))
+      assert(token.refreshToken == refreshToken)
     }
   }
 }

--- a/src/test/scala/com/github/dakatsuka/akka/http/oauth2/client/ClientSpec.scala
+++ b/src/test/scala/com/github/dakatsuka/akka/http/oauth2/client/ClientSpec.scala
@@ -99,8 +99,9 @@ class ClientSpec extends FlatSpec with DiagrammedAssertions with ScalaFutures wi
   "#getConnectionWithAccessToken" should "return outgoing connection flow with access token" in {
     val accessToken = AccessToken(
       accessToken = "xxx",
-      tokenType = "bearer",
-      expiresIn = 86400,
+      tokenType = Some("bearer"),
+      scope = Some("read:org,read:user"),
+      expiresIn = Some(86400),
       refreshToken = Some("yyy")
     )
 


### PR DESCRIPTION
Hey,
the token model did not fit to some oauth provider, e.g. GitHub. Therefore I generalized the token model a bit and changed tests accordingly.